### PR TITLE
Fix home feed interaction probabilities (Issue #24)

### DIFF
--- a/plugin-nostr/lib/service.js
+++ b/plugin-nostr/lib/service.js
@@ -5646,7 +5646,7 @@ Response (YES/NO):`;
              case 'quote':
                success = await this.postQuoteRepost(evt);
                break;
-             case 'reply':
+             case 'reply': {
                // Get thread context for better replies
                const threadContext = await this._getThreadContext(evt);
                const convId = this._getConversationIdFromEvent(evt);
@@ -5689,6 +5689,7 @@ Response (YES/NO):`;
                
                success = await this.postReply(evt, text);
                break;
+             }
            }
 
           if (success) {


### PR DESCRIPTION
## Summary

This PR addresses issue #24 by adjusting the home feed interaction probabilities to increase engagement while preventing spam.

### Changes Made

- **Increased reaction chance**: `homeFeedReactionChance` from 0.05 (5%) to 0.15 (15%)
- **Slightly increased repost chance**: `homeFeedRepostChance` from 0.005 (0.5%) to 0.01 (1%)  
- **Slightly increased quote chance**: `homeFeedQuoteChance` from 0.001 (0.1%) to 0.005 (0.5%)

### Rationale

The original probabilities were too restrictive (total 5.6% interaction chance), causing posts that were correctly analyzed as relevant to be skipped due to probabilistic filtering. This change:

- **Triples the reaction probability** (most common interaction type) to make the bot more engaging
- **Maintains low repost/quote rates** to prevent spam
- **Results in ~16.5% total interaction probability** - a significant increase without enabling every interaction

### Testing

- All existing tests pass
- Probability changes maintain the existing interaction logic
- "Like" reactions remain the most common interaction type

This should resolve the issue where relevant posts were being skipped despite correct analysis.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Home feed can now generate and post context-aware replies (including optional image handling) with safe fallbacks to avoid blocking other interactions.
* **Settings**
  * New runtime setting lets administrators control reply frequency; its value is shown at startup and constrained to a valid range.
* **Refactor**
  * Improved home feed lifecycle and unified queuing for all interaction types, including an unsubscribe handle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->