### PR TITLE
fix: increase maxTokens and prevent markdown wrapping in timeline lor…

### DIFF
--- a/plugin-nostr/lib/service.js
+++ b/plugin-nostr/lib/service.js
@@ -6926,7 +6926,7 @@ EXTRACT SPECIFICS:
 IF POSTS MENTION AGENT/BOT:
 - Treat as regular topic, focus on other content
 
-OUTPUT MANDATORY REQUIREMENTS (JSON IS THE ONLY VALID RESPONSE):
+OUTPUT MANDATORY REQUIREMENTS - RETURN RAW JSON ONLY (NO MARKDOWN, NO CODE FENCES, NO BACKTICKS):
 {
   "headline": "What PROGRESSED or EMERGED (<=18 words, not just 'X was discussed')",
   "narrative": "Focus on CHANGE, EVOLUTION, or NEW DEVELOPMENTS (3-5 sentences)",
@@ -6941,13 +6941,15 @@ OUTPUT MANDATORY REQUIREMENTS (JSON IS THE ONLY VALID RESPONSE):
 Tags from post metadata: ${rankedTags.join(', ') || 'none'}
 
 POSTS TO ANALYZE (${recentBatch.length} posts):
-${postLines} /// (REMEMBER TO OUTPUT JSON ONLY)`;
+${postLines}
+
+YOUR RESPONSE MUST START WITH { AND END WITH } - NO MARKDOWN FORMATTING`;
 
       const raw = await generateWithModelOrFallback(
         this.runtime,
         type,
         prompt,
-        { maxTokens: 480, temperature: 0.45 },
+        { maxTokens: 1000, temperature: 0.45 },
         (res) => this._extractTextFromModelResult(res),
         (s) => (typeof s === 'string' ? s.trim() : ''),
         () => null


### PR DESCRIPTION
…e JSON generation

Timeline lore summary generation was failing due to two issues:
1. maxTokens limit of 480 was too small, causing JSON responses to be truncated
2. Model was returning markdown-wrapped JSON (```json...```), adding overhead

Changes:
- Increased maxTokens from 480 to 1000 to allow complete JSON responses
- Updated prompt to explicitly request raw JSON without markdown formatting
- Added clear instruction to start with { and end with }

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced JSON output parsing and normalization for improved consistency and reliability.
  * Increased capacity for timeline lore summary generation, enabling more detailed and comprehensive summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->